### PR TITLE
Implement reusable mode switch logic across visualizers

### DIFF
--- a/src/hooks/useModeHistorySwitch.js
+++ b/src/hooks/useModeHistorySwitch.js
@@ -1,0 +1,58 @@
+import { useCallback } from 'react';
+
+/**
+ * Generic hook to handle mode switching without forcing a reset of user input.
+ *
+ * @param {Object} params
+ * @param {string} params.mode - Current mode value.
+ * @param {(m:string)=>void} params.setMode - Setter for mode.
+ * @param {boolean} params.isLoaded - Whether input is loaded.
+ * @param {() => any | null} params.parseInput - Returns normalized parsed input or null/throws if invalid.
+ * @param {Record<string, Function>} params.generators - Map of mode -> history generation function.
+ * @param {(step:number)=>void} params.setCurrentStep - Setter for current step index.
+ * @param {(msg:string)=>void} [params.onError] - Optional error reporter (alert, toast, etc.).
+ *
+ * Usage pattern inside a component:
+ * const handleModeChange = useModeHistorySwitch({
+ *   mode, setMode, isLoaded,
+ *   parseInput: () => ({ nums: parsedNums, k }),
+ *   generators: { 'brute-force': (input)=>..., optimal: (input)=>... },
+ *   setCurrentStep
+ * });
+ * ... onClick={() => handleModeChange('optimal')}
+ */
+export function useModeHistorySwitch({
+  mode,
+  setMode,
+  isLoaded,
+  parseInput,
+  generators,
+  setCurrentStep,
+  onError,
+}) {
+  return useCallback(
+    (nextMode) => {
+      if (!nextMode || nextMode === mode) return;
+      setMode(nextMode);
+      if (!isLoaded) return; // Nothing to regenerate yet
+      let parsed;
+      try {
+        parsed = parseInput();
+      } catch (e) {
+        if (onError) onError(e.message || 'Invalid input');
+        return;
+      }
+      if (parsed == null) return;
+      const gen = generators[nextMode];
+      if (typeof gen !== 'function') {
+        if (onError) onError(`No generator for mode: ${nextMode}`);
+        return;
+      }
+      gen(parsed);
+      setCurrentStep(0);
+    },
+    [mode, setMode, isLoaded, parseInput, generators, setCurrentStep, onError]
+  );
+}
+
+export default useModeHistorySwitch;

--- a/src/pages/Arrays/ContainerWithMostWater.jsx
+++ b/src/pages/Arrays/ContainerWithMostWater.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useModeHistorySwitch } from "../../hooks/useModeHistorySwitch";
 import {
   ArrowUp,
   Code,
@@ -209,6 +210,28 @@ const ContainerWithMostWater = () => {
     setHistory([]);
     setCurrentStep(-1);
   };
+  // Provide parsed input & generator mapping for generic mode switching
+  const parseInput = useCallback(() => {
+    const localHeights = heightsInput
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number);
+    if (localHeights.some(isNaN) || localHeights.length < 2) throw new Error("Invalid input");
+    return localHeights;
+  }, [heightsInput]);
+  const handleModeChange = useModeHistorySwitch({
+    mode,
+    setMode,
+    isLoaded,
+    parseInput,
+    generators: {
+      "brute-force": (h) => generateBruteForceHistory(h),
+      optimal: (h) => generateOptimalHistory(h),
+    },
+    setCurrentStep,
+    onError: () => {},
+  });
   const stepForward = useCallback(
     () => setCurrentStep((prev) => Math.min(prev + 1, history.length - 1)),
     [history.length]
@@ -477,10 +500,7 @@ const ContainerWithMostWater = () => {
 
       <div className="flex border-b border-gray-700 mb-6">
         <div
-          onClick={() => {
-            setMode("brute-force");
-            reset();
-          }}
+          onClick={() => handleModeChange("brute-force")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "brute-force"
               ? "border-sky-400 text-sky-400"
@@ -490,10 +510,7 @@ const ContainerWithMostWater = () => {
           Brute Force O(n²)
         </div>
         <div
-          onClick={() => {
-            setMode("optimal");
-            reset();
-          }}
+          onClick={() => handleModeChange("optimal")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "optimal"
               ? "border-sky-400 text-sky-400"

--- a/src/pages/Arrays/SubarrayRanges.jsx
+++ b/src/pages/Arrays/SubarrayRanges.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useModeHistorySwitch } from "../../hooks/useModeHistorySwitch";
 import {
   ArrowUp,
   Code,
@@ -307,10 +308,27 @@ const SubarrayRangesVisualizer = () => {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isLoaded, stepBackward, stepForward]);
 
-  const switchTab = (newMode) => {
-    setMode(newMode);
-    reset();
-  };
+  const parseInput = useCallback(() => {
+    const nums = numsInput
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number);
+    if (nums.some(isNaN) || nums.length === 0) throw new Error("Invalid input");
+    return nums;
+  }, [numsInput]);
+  const handleModeChange = useModeHistorySwitch({
+    mode,
+    setMode,
+    isLoaded,
+    parseInput,
+    generators: {
+      "brute-force": (n) => generateBruteForceHistory(n),
+      optimal: (n) => generateOptimalHistory(n),
+    },
+    setCurrentStep,
+    onError: () => {},
+  });
 
   const state = history[currentStep] || {};
   const { nums = [], line } = state;
@@ -743,7 +761,7 @@ const SubarrayRangesVisualizer = () => {
 
       <div className="flex border-b border-gray-700 mb-6">
         <div
-          onClick={() => switchTab("brute-force")}
+          onClick={() => handleModeChange("brute-force")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "brute-force"
               ? "border-teal-400 text-teal-400"
@@ -753,7 +771,7 @@ const SubarrayRangesVisualizer = () => {
           Brute Force O(n²)
         </div>
         <div
-          onClick={() => switchTab("optimal")}
+          onClick={() => handleModeChange("optimal")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "optimal"
               ? "border-teal-400 text-teal-400"

--- a/src/pages/Arrays/TrappingRainWater.jsx
+++ b/src/pages/Arrays/TrappingRainWater.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useModeHistorySwitch } from "../../hooks/useModeHistorySwitch";
 import {
   ArrowUp,
   Code,
@@ -267,6 +268,27 @@ const TrappingRainWater = () => {
     setHistory([]);
     setCurrentStep(-1);
   };
+  const parseInput = useCallback(() => {
+    const localHeights = heightsInput
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number);
+    if (localHeights.some(isNaN) || localHeights.length < 2) throw new Error("Invalid input");
+    return localHeights;
+  }, [heightsInput]);
+  const handleModeChange = useModeHistorySwitch({
+    mode,
+    setMode,
+    isLoaded,
+    parseInput,
+    generators: {
+      "brute-force": (h) => generateBruteForceHistory(h),
+      optimal: (h) => generateOptimalHistory(h),
+    },
+    setCurrentStep,
+    onError: () => {},
+  });
   const stepForward = useCallback(
     () => setCurrentStep((prev) => Math.min(prev + 1, history.length - 1)),
     [history.length]
@@ -539,10 +561,7 @@ const TrappingRainWater = () => {
 
       <div className="flex border-b border-gray-700 mb-6">
         <div
-          onClick={() => {
-            setMode("brute-force");
-            reset();
-          }}
+          onClick={() => handleModeChange("brute-force")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "brute-force"
               ? "border-blue-400 text-blue-400"
@@ -552,10 +571,7 @@ const TrappingRainWater = () => {
           Brute Force O(n²)
         </div>
         <div
-          onClick={() => {
-            setMode("optimal");
-            reset();
-          }}
+          onClick={() => handleModeChange("optimal")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "optimal"
               ? "border-blue-400 text-blue-400"

--- a/src/pages/LinkedList/LinkedListCycle.jsx
+++ b/src/pages/LinkedList/LinkedListCycle.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useModeHistorySwitch } from "../../hooks/useModeHistorySwitch";
 import {
   ArrowUp,
   Code,
@@ -283,6 +284,22 @@ const LinkedListCycle = () => {
     setNodes([]);
     setEdges([]);
   };
+  const parseInput = useCallback(() => {
+    if (nodes.length === 0) throw new Error("No list loaded");
+    return nodes;
+  }, [nodes]);
+  const handleModeChange = useModeHistorySwitch({
+    mode,
+    setMode,
+    isLoaded,
+    parseInput,
+    generators: {
+      "brute-force": (n) => generateBruteForceHistory(n),
+      optimal: (n) => generateOptimalHistory(n),
+    },
+    setCurrentStep,
+    onError: () => {},
+  });
 
   const stepForward = useCallback(
     () => setCurrentStep((prev) => Math.min(prev + 1, history.length - 1)),
@@ -530,10 +547,7 @@ const LinkedListCycle = () => {
 
       <div className="flex border-b border-gray-700 mb-6">
         <div
-          onClick={() => {
-            setMode("brute-force");
-            reset();
-          }}
+          onClick={() => handleModeChange("brute-force")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "brute-force"
               ? "border-sky-400 text-sky-400"
@@ -543,10 +557,7 @@ const LinkedListCycle = () => {
           Brute Force O(n)
         </div>
         <div
-          onClick={() => {
-            setMode("optimal");
-            reset();
-          }}
+          onClick={() => handleModeChange("optimal")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "optimal"
               ? "border-sky-400 text-sky-400"

--- a/src/pages/LinkedList/ReverseLinkedList.jsx
+++ b/src/pages/LinkedList/ReverseLinkedList.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useModeHistorySwitch } from "../../hooks/useModeHistorySwitch";
 import {
   ArrowUp,
   Code,
@@ -86,6 +87,29 @@ const ReverseLinkedList = () => {
     }
     setIsLoaded(true);
   };
+
+  const parseInput = useCallback(() => {
+    const data = listInput
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number);
+    if (data.some(isNaN) || data.length === 0) throw new Error("Invalid list input");
+    return data;
+  }, [listInput]);
+
+  const handleModeChange = useModeHistorySwitch({
+    mode,
+    setMode,
+    isLoaded,
+    parseInput,
+    generators: {
+      iterative: (d) => generateIterativeHistory(d),
+      recursive: (d) => generateRecursiveHistory(d),
+    },
+    setCurrentStep,
+    onError: (m) => console.warn(m),
+  });
 
   const generateIterativeHistory = useCallback((data) => {
     const newHistory = [];
@@ -422,10 +446,7 @@ const ReverseLinkedList = () => {
       </div>
       <div className="flex border-b-2 border-gray-700 mb-6">
         <div
-          onClick={() => {
-            setMode("iterative");
-            reset();
-          }}
+          onClick={() => handleModeChange("iterative")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "iterative"
               ? "border-sky-400 text-sky-400"
@@ -435,10 +456,7 @@ const ReverseLinkedList = () => {
           Iterative
         </div>
         <div
-          onClick={() => {
-            setMode("recursive");
-            reset();
-          }}
+          onClick={() => handleModeChange("recursive")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "recursive"
               ? "border-sky-400 text-sky-400"

--- a/src/pages/SlidingWindows/SlidingWindowMaximum.jsx
+++ b/src/pages/SlidingWindows/SlidingWindowMaximum.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useModeHistorySwitch } from "../../hooks/useModeHistorySwitch";
 import { Code, Clock, Maximize2, TrendingUp, Layers } from "lucide-react";
 
 const SlidingWindowMaximum = () => {
@@ -239,6 +240,28 @@ const SlidingWindowMaximum = () => {
     setHistory([]);
     setCurrentStep(-1);
   };
+  const parseInput = useCallback(() => {
+    const nums = numsInput
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number);
+    const k = parseInt(kInput, 10);
+    if (nums.some(isNaN) || isNaN(k) || k <= 0) throw new Error("Invalid input");
+    return { nums, k };
+  }, [numsInput, kInput]);
+  const handleModeChange = useModeHistorySwitch({
+    mode,
+    setMode,
+    isLoaded,
+    parseInput,
+    generators: {
+      "brute-force": ({ nums, k }) => generateBruteForceHistory(nums, k),
+      optimal: ({ nums, k }) => generateOptimalHistory(nums, k),
+    },
+    setCurrentStep,
+    onError: () => {},
+  });
 
   const stepForward = useCallback(
     () => setCurrentStep((prev) => Math.min(prev + 1, history.length - 1)),
@@ -528,10 +551,7 @@ const SlidingWindowMaximum = () => {
 
       <div className="flex border-b-2 border-gray-700 mb-6">
         <div
-          onClick={() => {
-            setMode("brute-force");
-            reset();
-          }}
+          onClick={() => handleModeChange("brute-force")}
           className={`cursor-pointer p-4 px-8 border-b-4 transition-all font-semibold ${
             mode === "brute-force"
               ? "border-blue-400 text-blue-400 bg-blue-500/10"
@@ -541,10 +561,7 @@ const SlidingWindowMaximum = () => {
           Brute Force O(n·k)
         </div>
         <div
-          onClick={() => {
-            setMode("optimal");
-            reset();
-          }}
+          onClick={() => handleModeChange("optimal")}
           className={`cursor-pointer p-4 px-8 border-b-4 transition-all font-semibold ${
             mode === "optimal"
               ? "border-blue-400 text-blue-400 bg-blue-500/10"

--- a/src/pages/Stack/LargestRectangleHistogram.jsx
+++ b/src/pages/Stack/LargestRectangleHistogram.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useModeHistorySwitch } from "../../hooks/useModeHistorySwitch";
 import {
   ArrowUp,
   Code,
@@ -294,6 +295,27 @@ const LargestRectangleHistogram = () => {
     setHistory([]);
     setCurrentStep(-1);
   };
+  const parseInput = useCallback(() => {
+    const localHeights = heightsInput
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number);
+    if (localHeights.some(isNaN) || localHeights.length < 1) throw new Error("Invalid input");
+    return localHeights;
+  }, [heightsInput]);
+  const handleModeChange = useModeHistorySwitch({
+    mode,
+    setMode,
+    isLoaded,
+    parseInput,
+    generators: {
+      "brute-force": (h) => generateBruteForceHistory(h),
+      optimal: (h) => generateOptimalHistory(h),
+    },
+    setCurrentStep,
+    onError: () => {},
+  });
   const stepForward = useCallback(
     () => setCurrentStep((prev) => Math.min(prev + 1, history.length - 1)),
     [history.length]
@@ -750,10 +772,7 @@ const LargestRectangleHistogram = () => {
 
       <div className="flex border-b border-gray-700 mb-6">
         <div
-          onClick={() => {
-            setMode("brute-force");
-            reset();
-          }}
+          onClick={() => handleModeChange("brute-force")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "brute-force"
               ? "border-green-400 text-green-400"
@@ -763,10 +782,7 @@ const LargestRectangleHistogram = () => {
           Brute Force O(n²)
         </div>
         <div
-          onClick={() => {
-            setMode("optimal");
-            reset();
-          }}
+          onClick={() => handleModeChange("optimal")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "optimal"
               ? "border-green-400 text-green-400"

--- a/src/pages/Stack/SubarrayRanges.jsx
+++ b/src/pages/Stack/SubarrayRanges.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useModeHistorySwitch } from "../../hooks/useModeHistorySwitch";
 import {
   ArrowUp,
   Code,
@@ -307,10 +308,27 @@ const SubarrayRangesVisualizer = () => {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isLoaded, stepBackward, stepForward]);
 
-  const switchTab = (newMode) => {
-    setMode(newMode);
-    reset();
-  };
+  const parseInput = useCallback(() => {
+    const localNums = numsInput
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number);
+    if (localNums.some(isNaN) || localNums.length === 0) throw new Error("Invalid input");
+    return localNums;
+  }, [numsInput]);
+  const handleModeChange = useModeHistorySwitch({
+    mode,
+    setMode,
+    isLoaded,
+    parseInput,
+    generators: {
+      "brute-force": (n) => generateBruteForceHistory(n),
+      optimal: (n) => generateOptimalHistory(n),
+    },
+    setCurrentStep,
+    onError: (m) => console.warn(m),
+  });
 
   const state = history[currentStep] || {};
   const { nums = [], line } = state;
@@ -743,7 +761,7 @@ const SubarrayRangesVisualizer = () => {
 
       <div className="flex border-b border-gray-700 mb-6">
         <div
-          onClick={() => switchTab("brute-force")}
+          onClick={() => handleModeChange("brute-force")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "brute-force"
               ? "border-teal-400 text-teal-400"
@@ -753,7 +771,7 @@ const SubarrayRangesVisualizer = () => {
           Brute Force O(n²)
         </div>
         <div
-          onClick={() => switchTab("optimal")}
+          onClick={() => handleModeChange("optimal")}
           className={`cursor-pointer p-3 px-6 border-b-4 transition-all ${
             mode === "optimal"
               ? "border-teal-400 text-teal-400"


### PR DESCRIPTION
Added hook to prevent unnecessary input resets, updated all brute/optimal (or iterative/recursive) components, and cleaned obsolete reset handlers.
<img width="1583" height="797" alt="image" src="https://github.com/user-attachments/assets/73802c25-0af9-429c-9475-fb1640f0d795" />
<img width="1595" height="768" alt="Screenshot 2025-10-09 103215" src="https://github.com/user-attachments/assets/9f66ab0d-9d47-47cd-aae9-58cf2d7d18e0" />
