### PR TITLE
Reposition scroll-to-top button for better readability

### DIFF
--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { ArrowUp } from "lucide-react"; // Using a modern icon for attractiveness
+import { ArrowUp } from "lucide-react";
 
 const ScrollToTop = () => {
   const [visible, setVisible] = useState(false);
@@ -23,7 +23,7 @@ const ScrollToTop = () => {
         <button
           onClick={scrollToTop}
           className="
-            fixed bottom-8 left-1/2 transform -translate-x-1/2 z-50
+            fixed bottom-8 right-8 z-50
             p-4 sm:p-5 bg-gradient-to-r from-blue-500 to-purple-500
             rounded-full shadow-2xl text-white flex items-center justify-center
             hover:scale-110 hover:shadow-xl hover:shadow-purple-500/50
@@ -36,7 +36,6 @@ const ScrollToTop = () => {
         </button>
       )}
 
-      {/* subtle bounce animation */}
       <style>{`
         @keyframes bounce-subtle {
           0%, 100% { transform: translateY(0); }


### PR DESCRIPTION
closes #87 

This PR repositions the scroll-to-top button to the right side of the page so that it no longer overlaps the content or visual lines, improving readability and overall user experience. The button remains fully functional and consistent with the site’s design and responsiveness, providing a cleaner and more professional layout.