### PR TITLE
 🐛 Bug Fix: Corrected Animation Speed Behavior in Binary Search Visualizations

### DIFF
--- a/src/pages/BinarySearch/BinarySearchBasic.jsx
+++ b/src/pages/BinarySearch/BinarySearchBasic.jsx
@@ -92,6 +92,9 @@ const BinarySearchBasic = () => {
 
   const state = history[currentStep] || {};
 
+  const maxSpeed = 1500;
+  const minSpeed = 100;
+
   const load = useCallback(() => {
     const arr = arrInput
       .split(",")
@@ -205,7 +208,7 @@ const BinarySearchBasic = () => {
           }
           return s + 1;
         });
-      }, speed);
+      }, (maxSpeed - speed));
     } else {
       clearInterval(playRef.current);
     }
@@ -314,8 +317,8 @@ const BinarySearchBasic = () => {
                 <label className="text-sm text-gray-300">Speed</label>
                 <input
                   type="range"
-                  min={100}
-                  max={1500}
+                  min={minSpeed}
+                  max={maxSpeed}
                   step={50}
                   value={speed}
                   onChange={(e) => setSpeed(parseInt(e.target.value, 10))}

--- a/src/pages/BinarySearch/FindFirstAndLastPosition.jsx
+++ b/src/pages/BinarySearch/FindFirstAndLastPosition.jsx
@@ -88,6 +88,9 @@ const FindFirstAndLastPosition = () => {
   const [speed, setSpeed] = useState(1000);
   const playRef = useRef(null);
 
+  const maxSpeed = 2000;
+  const minSpeed = 100;
+
   const state = history[currentStep] || {};
 
   const generateHistory = useCallback(() => {
@@ -281,7 +284,7 @@ const FindFirstAndLastPosition = () => {
           }
           return s + 1;
         });
-      }, speed);
+      }, (maxSpeed - speed));
     } else {
       clearInterval(playRef.current);
     }
@@ -405,8 +408,8 @@ const FindFirstAndLastPosition = () => {
                   <label className="text-sm text-gray-300">Speed</label>
                   <input
                     type="range"
-                    min={100}
-                    max={2000}
+                    min={minSpeed}
+                    max={maxSpeed}
                     step={50}
                     value={speed}
                     onChange={(e) =>{

--- a/src/pages/BinarySearch/FindMinimumInRotatedSortedArray.jsx
+++ b/src/pages/BinarySearch/FindMinimumInRotatedSortedArray.jsx
@@ -85,6 +85,9 @@ const FindMinimumInRotatedSortedArray = () => {
   const [speed, setSpeed] = useState(1200);
   const playRef = useRef(null);
 
+  const minSpeed = 100;
+  const maxSpeed = 1500;
+
   const state = history[currentStep] || {};
 
   const load = useCallback(() => {
@@ -177,7 +180,7 @@ const FindMinimumInRotatedSortedArray = () => {
           }
           return s + 1;
         });
-      }, speed);
+      }, (maxSpeed -  speed));
     } else {
       clearInterval(playRef.current);
     }
@@ -281,8 +284,8 @@ const FindMinimumInRotatedSortedArray = () => {
                 <label className="text-sm text-gray-300">Speed</label>
                 <input
                   type="range"
-                  min={100}
-                  max={1500}
+                  min={minSpeed}
+                  max={maxSpeed}
                   step={50}
                   value={speed}
                   // Note: Changed onChange logic to match the target example

--- a/src/pages/BinarySearch/Search2DMatrix.jsx
+++ b/src/pages/BinarySearch/Search2DMatrix.jsx
@@ -83,6 +83,9 @@ const Search2DMatrix = () => {
   const [speed, setSpeed] = useState(1000);
   const playRef = useRef(null);
 
+  const minSpeed = 100;
+  const maxSpeed = 2000;
+
   const state = history[currentStep] || {};
 
   const codeContent = {
@@ -346,7 +349,7 @@ const Search2DMatrix = () => {
           }
           return s + 1;
         });
-      }, speed);
+      }, (maxSpeed - speed));
     } else {
       clearInterval(playRef.current);
     }
@@ -460,12 +463,12 @@ const Search2DMatrix = () => {
                   <label className="text-sm text-gray-300">Speed</label>
                   <input
                     type="range"
-                    min={100}
-                    max={2000}
+                    min={minSpeed}
+                    max={maxSpeed}
                     step={50}
                     value={speed}
                     onChange={(e) =>
-                      setSpeed(2100 - parseInt(e.target.value, 10))
+                      setSpeed(parseInt(e.target.value, 10))
                     }
                     className="w-24"
                   />


### PR DESCRIPTION
### 🐛 Bug Fix: 

This PR fixes the inverted speed logic affecting several sections of the Binary Search visualization. Previously, increasing the speed value caused the animation to slow down (and vice versa). The sections which were improved includes:

1. Basic Binary Search
2. Find First and Last Position
3. Find Minimum in Rotated Sorted Array
4. Search a 2D Matrix

This PR aims to close #235 

---

### 🧠 How It Works
* Earlier for setting animation interval we were directly using speed useState, this useState contains speed value via speed selector input.
* Due to this flow when we increase the speed, animation interval was being increased.
* I introduced a new maxSpeed constant variable and in animation useEffect changed interval to (maxSpeed - speed).
* This new approach helped in making animation speed behaviour normal.

---

### 🚀 Changes Made
* Introduced two new constant variables, maxSpeed and minSpeed making it easy to keep track of speed limit.
* Made animation interval to be (maxSpeed - speed)

---

While working I observed that speed selector input of "Search a 2D Matrix" was also inverted similar to that of "Find First and Last Position of Element" in issue #230 

Before:

https://github.com/user-attachments/assets/2006ac88-a8e0-4cce-9986-beb3b4b878dc

After:

https://github.com/user-attachments/assets/60bacb1c-c94d-444b-8c22-185bc18c16be


---
### 🧪 Testing
✅ Tested the UI after changes were made by changing speed of  Find First and Last Position of Element section.
✅ Ensured existing features were not affected

### Final Working demo

https://github.com/user-attachments/assets/2639c49b-2906-42e9-bcc9-cf15125ff300


