### PR TITLE
fixed issue #247 reference error in Strings.jsx by importing relevant…

### DIFF
--- a/src/pages/Strings/Strings.jsx
+++ b/src/pages/Strings/Strings.jsx
@@ -29,13 +29,17 @@ import ReverseWordsVisualizer from "./ReverseWords.jsx";
 import StringCompressionVisualizer from "./StringCompression.jsx";
 import IsSubsequence from "./IsSubSequence.jsx";
 
+// importing problems as PROBLEM_CATALOG from catalog.js to see if this fixes the issue and star button - @prajithravisankar
+import { problems as PROBLEM_CATALOG } from "../../search/catalog.js";
+import StarButton from "../../components/StarButton.jsx";
+
 
 function AlgorithmList({ navigate }) {
   const [hoveredIndex, setHoveredIndex] = useState(null);
   const [filter, setFilter] = useState("all");
 
   // ✅ Get String problems directly from the master catalog
-  const stringAlgorithms = PROBLEM_CATALOG.filter(p => p.category === 'Strings');
+  const stringAlgorithms = PROBLEM_CATALOG.filter(p => p.category === 'Strings'); // the error's origin - @prajithravisankar
   
   // ❌ The local 'algorithms' array has been DELETED.
 


### PR DESCRIPTION
Fixes #247 

### Description
This PR fixes a runtime `ReferenceError` caused by the missing `PROBLEM_CATALOG` import in `Strings.jsx`.

Previously, the file attempted to use:

```js
const stringAlgorithms = PROBLEM_CATALOG.filter(p => p.category === 'Strings');
````

without importing `PROBLEM_CATALOG`, resulting in:

```
Uncaught ReferenceError: PROBLEM_CATALOG is not defined
```

Changes Made

* Added the missing import statement at the top of `Strings.jsx`:

  ```js
  import { problems as PROBLEM_CATALOG } from "../../search/catalog";
  ```
* Verified the relative path to `catalog.js` resolves correctly (`src/search/catalog.js`).
* Tested the **Strings** page — all problems now load successfully without console errors.

### Verification

Steps taken to verify the fix:

1. Ran `npm run dev`.
2. Navigated to **Strings** from the home page.
3. Confirmed:

   * No runtime errors in the console.
   * String problems display correctly from the master catalog.

### Evidence 



https://github.com/user-attachments/assets/40e81afe-dd66-40a2-878c-2260f0acb3f5


https://github.com/user-attachments/assets/a0295f51-fe46-428e-b185-f66f19d93b34




### Additional Notes

* This change ensures each module imports `PROBLEM_CATALOG`, and StarButton component explicitly rather than assuming shared scope.
* No UI or functionality changes outside of error resolution.